### PR TITLE
notes on installing `agama`

### DIFF
--- a/docs/pages/install.rst
+++ b/docs/pages/install.rst
@@ -45,14 +45,14 @@ Package installation
         and you should be all set! Now it's time to learn about `Getting Started <getting_started.ipynb>`_ with ``cogsworth``.
 
     .. tab-item:: Development (from GitHub)
-        
+
         .. warning::
 
             We don't guarantee that there won't be mistakes or bugs in the development version, use at your own risk!
 
         The latest development version is available directly from our `GitHub Repo
         <https://github.com/TomWagg/cogsworth>`_. To start, clone the repository onto your machine: ::
-        
+
             git clone https://github.com/TomWagg/cogsworth
             cd cogsworth
 
@@ -69,11 +69,22 @@ Package installation
 
             pip install .
 
+        and you should be all set! Now it's time to learn about `Getting Started <getting_started.ipynb>`_ with ``cogsworth``.
+
         **OPTIONALLY** if you want to install some of the ``cogsworth`` extras (**this is necessary for some tutorials and examples**, particularly those on observables predictions and postprocessing hydrodynamical simulations) then you can do so by instead running::
 
             pip install '.[extras]'
 
-        and you should be all set! Now it's time to learn about `Getting Started <getting_started.ipynb>`_ with ``cogsworth``.
+	**N.B.:** `agama<https://github.com/GalacticDynamics-Oxford/Agama>`_ is needed, for example, to use action-angle formulations of the potential. It is installed as part of the extras, but this can sometimes generate errors. If you run into these, you can install ``agama`` manually with::
+
+	  python -m pip install numpy setuptools wheel --no-build-isolation
+          git clone https://github.com/GalacticDynamics-Oxford/Agama.git agama
+          cd agama
+          pip install . --config-settings --build-option=--yes --no-build-isolation
+          cd ..
+
+	Before pip-installing `.[extras]`.
+
 
 .. tip::
     If you also want to work with Jupyter notebooks then you'll also need to install jupyter/ipython to this environment!
@@ -93,11 +104,11 @@ Dependencies
     .. grid-item::
 
         .. card::
-            
+
             .. div:: sd-text-center sd-fs-4 sd-text-primary sd-font-weight-bolder
 
                 Core Dependencies
-            
+
             .. div:: sd-text-center sd-fs-6 sd-font-italic
 
                 Install via: pip install cogsworth
@@ -115,11 +126,11 @@ Dependencies
             - :mod:`astropy` for coordinate transformations
 
         .. card::
-            
+
             .. div:: sd-text-center sd-fs-4 sd-text-primary sd-font-weight-bolder
 
                 Development Dependencies
-            
+
             .. div:: sd-text-center sd-fs-6 sd-font-italic
 
                 Install via: pip install 'cogsworth[all]'
@@ -127,17 +138,17 @@ Dependencies
             ^^^^^^^^^^^^^^^^^^^^^^^^
 
             For developers of ``cogsworth`` there are also additional dependencies for testing (``pytest``, ``coverage``, etc.) and documentation building (``sphinx``, ``nbspinx``, etc.).
-            
+
             Most users do **not** need these dependencies.
 
     .. grid-item::
 
         .. card::
-            
+
             .. div:: sd-text-center sd-fs-4 sd-text-primary sd-font-weight-bolder
 
                 Optional Dependencies
-            
+
             .. div:: sd-text-center sd-fs-6 sd-font-italic
 
                 Install via: pip install 'cogsworth[extras]'
@@ -159,7 +170,7 @@ Dependencies
             **LISA gravitational wave sources**:
 
             - :mod:`legwork` for calculating LISA gravitational wave signals
-            
+
             **Action-based galactic potentials**:
 
             - :mod:`agama` for action-based galactic potentials
@@ -191,7 +202,7 @@ Gaia empirical selection function
 
 If you'd like to use ``cogsworth`` to make predictions for which stars are observable by Gaia then you'll need
 to run the following to ensure there's a directory for the files::
-    
+
     import os
     gaia_unlimited_path = os.path.join(os.path.expanduser('~'), ".gaiaunlimited")
     if not os.path.isdir(gaia_unlimited_path):


### PR DESCRIPTION
Installing the `extras` when installing from github the dev version runs into issues when dealing with `agama`. In my case this is the error I get:

``` Building wheels for collected packages: cogsworth, agama
  Building wheel for cogsworth (pyproject.toml) ... done
  Created wheel for cogsworth: filename=cogsworth-3.2.3-py3-none-any.whl size=91424 sha256=30690ecda4616d44da2e650dbac45c61b1f9b711b00aae0c7d806d80216fec75
  Stored in directory: /tmp/pip-ephem-wheel-cache-af9560sx/wheels/cb/41/c4/7b4ee24febc71c2dc307dfed4f60b4200e0dd57caf97e4cea7

    ==== Checking supported compiler options and available libraries ====

  Building wheel for agama (pyproject.toml) ... -    **** Compiling with OpenMP support ****
error
  error: subprocess-exited-with-error
  
  × Building wheel for agama (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      
          ==== Checking supported compiler options and available libraries ====
      
      c++ test.cpp -o test.out -fPIC -Wall -O2
      c++ test.cpp -o test.out -fPIC -Wall -O2 -march=native
      c++ test.cpp -o test.out -fPIC -Wall -O2 -march=native -fopenmp -Werror -Wno-unknown-pragmas
          **** Compiling with OpenMP support ****
      c++: error: unrecognized command-line option '-qno-opt-dynamic-align'
      c++ test.cpp -o test.out -fPIC -Wall -O2 -march=native -fopenmp -std=c++11
      c++ test.cpp -o test.out -fPIC -Wall -O2 -march=native -fopenmp -std=c++11 -qno-opt-dynamic-align
      c++ test.cpp -o test.out -fPIC -Wall -O2 -march=native -fopenmp -std=c++11 -Werror -Wno-missing-field-initializers
      c++ test.cpp -o test.out -fPIC -Wall -O2 -march=native -fopenmp -std=c++11 -Wno-missing-field-initializers -Werror -Wno-cast-function-type
      error: NumPy is not present - python extension cannot be compiled.
      If you see this error when installing via pip, and are sure that your python environment actually has numpy installed, you may need to run pip with a command-line argument --no-build-isolation, and make sure that setuptools and wheel packages are also installed.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for agama
Successfully built cogsworth
Failed to build agama
error: failed-wheel-build-for-install

× Failed to build installable wheels for some pyproject.toml based projects
╰─> agama
```

This PR adds to the documentation instructions to manually pre-install `agama` when installing the dev version of cogsworth from github *with the extras*, using the manual installation from:
 https://github.com/TomWagg/cogsworth/blob/main/.github/workflows/test_cogsworth.yml#L29-L39
 
 