### PR TITLE
`tphys` from `kick_info`

### DIFF
--- a/docs/modules/changelog.rst
+++ b/docs/modules/changelog.rst
@@ -8,6 +8,7 @@ This page tracks all of the changes that have been made to ``cogsworth``. We fol
 =====
 
 - Bug fix: Ensure workers in the multiprocessing pool have different random seeds to avoid duplicate samples when sampling initial binaries with multiple processes.
+- Code cleanup: events.py now uses the tphys column directly from the kick_info table rather than the bpp table (recent update to COSMIC)
 
 4.0.1
 =====

--- a/docs/tutorials/pop_settings/pop_synth.ipynb
+++ b/docs/tutorials/pop_settings/pop_synth.ipynb
@@ -123,7 +123,7 @@
     {
      "data": {
       "text/plain": [
-       "'0.92'"
+       "'0.86'"
       ]
      },
      "execution_count": 4,
@@ -150,7 +150,15 @@
    "execution_count": 5,
    "id": "61ee2650-6ae8-4d61-82b8-68b18ed1c5ff",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[93mcogsworth warning: \u001b[0mYou passed settings for SSE (in `Population.SSE_settings`) but your initial binary table already has settings saved in its columns. cogsworth will use the settings found in the table.\n"
+     ]
+    }
+   ],
    "source": [
     "# we can drop the BSE_settings and just change the initial_binaries settings\n",
     "p.BSE_settings = {}\n",
@@ -168,7 +176,7 @@
     {
      "data": {
       "text/plain": [
-       "'0.92'"
+       "'0.86'"
       ]
      },
      "execution_count": 6,
@@ -208,18 +216,21 @@
    "id": "cfc8a3d7-7dbe-49e9-a20d-28bae5864a9b",
    "metadata": {
     "raw_mimetype": "text/restructuredtext",
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "raw"
+    }
    },
    "source": [
     "Common-envelope example\n",
     "-----------------------\n",
     " \n",
-    "Let's do another example in which we change the efficiency of the common-envelope phase (``alpha1``), which is defined as the fraction of orbital energy that goes into unbinding the envelope."
+    "Let's do another example in which we change the efficiency of the common-envelope phase (``alpha1``), which is defined as the fraction of orbital energy that goes into unbinding the envelope. ``COSMIC`` defines alpha separately for the primary and secondary (``alpha1_1`` and ``alpha1_2``) but we will set them to be the same here."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "6f198ade-1078-4ec3-8a7a-b6fcfcfe0c7e",
    "metadata": {},
    "outputs": [
@@ -228,29 +239,29 @@
      "output_type": "stream",
      "text": [
       "Run for alpha = 10\n",
-      "  117 binaries experience at least one common-envelope event\n",
-      "  50.4% of these resulted in a stellar merger\n",
-      "  For surviving systems, mean separation immediately after the CE is 24.59 Rsun\n",
+      "  108 binaries experience at least one common-envelope event\n",
+      "  67.6% of these resulted in a stellar merger\n",
+      "  For surviving systems, mean separation immediately after the CE is 14.00 Rsun\n",
       "\n",
       "Run for alpha = 2\n",
-      "  117 binaries experience at least one common-envelope event\n",
-      "  74.4% of these resulted in a stellar merger\n",
-      "  For surviving systems, mean separation immediately after the CE is 9.92 Rsun\n",
+      "  108 binaries experience at least one common-envelope event\n",
+      "  77.8% of these resulted in a stellar merger\n",
+      "  For surviving systems, mean separation immediately after the CE is 9.77 Rsun\n",
       "\n",
       "Run for alpha = 1\n",
-      "  117 binaries experience at least one common-envelope event\n",
-      "  79.5% of these resulted in a stellar merger\n",
-      "  For surviving systems, mean separation immediately after the CE is 5.68 Rsun\n",
+      "  108 binaries experience at least one common-envelope event\n",
+      "  80.6% of these resulted in a stellar merger\n",
+      "  For surviving systems, mean separation immediately after the CE is 8.60 Rsun\n",
       "\n",
       "Run for alpha = 0.5\n",
-      "  117 binaries experience at least one common-envelope event\n",
-      "  85.5% of these resulted in a stellar merger\n",
-      "  For surviving systems, mean separation immediately after the CE is 2.88 Rsun\n",
+      "  108 binaries experience at least one common-envelope event\n",
+      "  81.5% of these resulted in a stellar merger\n",
+      "  For surviving systems, mean separation immediately after the CE is 7.89 Rsun\n",
       "\n",
       "Run for alpha = 0.1\n",
-      "  117 binaries experience at least one common-envelope event\n",
-      "  92.3% of these resulted in a stellar merger\n",
-      "  For surviving systems, mean separation immediately after the CE is 0.28 Rsun\n",
+      "  108 binaries experience at least one common-envelope event\n",
+      "  82.4% of these resulted in a stellar merger\n",
+      "  For surviving systems, mean separation immediately after the CE is 7.24 Rsun\n",
       "\n"
      ]
     }
@@ -265,7 +276,9 @@
     "for alpha in [10, 2, 1, 0.5, 0.1]:\n",
     "    # change the setting and perform evolution\n",
     "    p.BSE_settings = {}\n",
-    "    p.initial_binaries[\"alpha1\"] = alpha\n",
+    "    p.SSE_settings = {}\n",
+    "    p.initial_binaries[\"alpha1_1\"] = alpha\n",
+    "    p.initial_binaries[\"alpha1_2\"] = alpha\n",
     "    p.perform_stellar_evolution()\n",
     "    \n",
     "    # find all binaries that start a CE and how many end as a mergers\n",
@@ -344,7 +357,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scipy >= 1.8",
     "pandas >= 2.1",
     "gala >= 1.11.0",
-    "cosmic-popsynth >= 4.1, < 4.2",
+    "cosmic-popsynth >= 4.2, < 4.3",
 ]
 
 [project.urls]

--- a/src/cogsworth/events.py
+++ b/src/cogsworth/events.py
@@ -7,15 +7,9 @@ def identify_events(p):
 
     # reduce kick info to just the rows that contain supernova events
     sn_kicks = p.kick_info[p.kick_info["star"] > 0.0][
-        ["star", "disrupted", "delta_vsysx_1", "delta_vsysy_1", "delta_vsysz_1",
+        ["tphys", "star", "disrupted", "delta_vsysx_1", "delta_vsysy_1", "delta_vsysz_1",
         "delta_vsysx_2", "delta_vsysy_2", "delta_vsysz_2", "bin_num"]
     ]
-
-    # reduce bpp to just SN rows
-    sn_bpp = p.bpp[p.bpp["evol_type"].isin([15, 16])][["tphys", "evol_type", "bin_num", "sep"]]
-
-    # add a star column for joining to kick_info, evol_type = 15 -> star 1 and evol_type = 16 -> star 2
-    sn_bpp["star"] = sn_bpp["evol_type"].map({15: 1, 16: 2})
 
     # randomly drawn phase and inclination angles as necessary
     for col in ["phase_sn_1", "phase_sn_2"]:
@@ -26,8 +20,8 @@ def identify_events(p):
             p.initC[col] = np.arccos(2 * np.random.rand(len(p.initC)) - 1.0)
 
     # same for initC
-    sn_initC = p.initC.loc[sn_bpp.index][["inc_sn_1", "phase_sn_1", "inc_sn_2", "phase_sn_2", "bin_num"]]
-    sn_initC["star"] = sn_bpp["star"].values
+    sn_initC = p.initC.loc[sn_kicks.index][["inc_sn_1", "phase_sn_1", "inc_sn_2", "phase_sn_2", "bin_num"]]
+    sn_initC["star"] = sn_kicks["star"].values
 
     # put inc_sn and phase_sn in their own columns based on star
     sn_initC["inc"] = None
@@ -41,7 +35,7 @@ def identify_events(p):
     sn_initC = sn_initC.drop(columns=["inc_sn_1", "phase_sn_1", "inc_sn_2", "phase_sn_2"])
 
     # join the tables together to get all the relevant info in one place
-    sn_info = sn_bpp.merge(sn_kicks, on=["bin_num", "star"]).merge(sn_initC, on=["bin_num", "star"])
+    sn_info = sn_kicks.merge(sn_initC, on=["bin_num", "star"])
     sn_info.index = sn_info["bin_num"].values
 
     # primary stars use delta_vsysx_1 for every supernova

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -27,6 +27,7 @@ class Test(unittest.TestCase):
         bpp.index = bpp["bin_num"].values
 
         kick_info_dict = {
+            "tphys": [0, 1, 2, 3, 4],
             "star": [0, 1, 1, 1, 2],
             "disrupted": [0, 0, 1, 0, 1],
             "delta_vsysx_1": [0, 0, 0, 0, 0],


### PR DESCRIPTION
Bump to COSMIC v4.2+.

Use `tphys` from kick_info now it's part of that table instead of merging with the bpp tables (faster _and_ easier!)

This will close #216, by updating both CE alpha variables in the variations.